### PR TITLE
fix: add reverseproxy env option and some fixed to work in ubuntu

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -16,6 +16,11 @@ echo >> ~/.bashrc && echo "export PATH=\"$PATH:/<PATH_TO_MY_REPO>/.bin\"" >> ~/.
 # ex: echo >> ~/.bashrc && echo "export PATH=\"$PATH:/mnt/d/Code/Archetypical/VDK/.bin\"" >> ~/.bashrc
 ```
 
+You may also need to create a secret in the ns flux-system with your GITHUB_VDK_TOKEN.
+``
+
+``
+
 > **_NOTE_**: You can run the commands for your own shell script login (e.g .zshrc, .profile). Remember to source it if you dont exit the terminal:
 
 ```
@@ -58,5 +63,11 @@ sudo launchctl load /Library/LaunchDaemons/org.nixos.nix-daemon.plist
     devbox shell
 ```
 - Run `vega --help` to see the available commands
+
+### Configuration options
+
+If you already have a process listening on your host on port 443, you will have issues with the vega reverse proxy.
+You can either stop the existing process or change the port by defining the environment variable `REVERSE_PROXY_HOST_PORT`. 
+The default port is 443.
 
 

--- a/cli/src/Vdk/Constants/Containers.cs
+++ b/cli/src/Vdk/Constants/Containers.cs
@@ -2,10 +2,10 @@ namespace Vdk.Constants;
 
 public static class Containers
 {
-    public const string RegistryName = "registry";
+    public const string RegistryName = "vega-registry";
     public const string RegistryImage = "registry:2";
     public const int RegistryContainerPort = 5000;
     public const int RegistryHostPort = 5000;
-    public const string ProxyName = "nginx";
+    public const string ProxyName = "vega-proxy";
     public const string ProxyImage = "nginx:latest";
 }

--- a/cli/src/Vdk/Properties/launchSettings.json
+++ b/cli/src/Vdk/Properties/launchSettings.json
@@ -2,7 +2,10 @@
   "profiles": {
     "Vdk": {
       "commandName": "Project",
-      "commandLineArgs": "init"
+      "commandLineArgs": "create cluster",
+      "environmentVariables": {
+        "GITHUB_TOKEN": "xxxxx"
+      }
     },
     "WSL": {
       "commandName": "WSL2",

--- a/cli/src/Vdk/Services/FluxClient.cs
+++ b/cli/src/Vdk/Services/FluxClient.cs
@@ -15,7 +15,10 @@ public class FluxClient : IFluxClient
 
     public void Bootstrap(string path, string branch = DefaultBranch)
     {
-        _shell.Execute("flux",
+        _console.WriteLine("Flux bootstrapping. This may take a few minutes. Please wait...");
+        try
+        {
+            _shell.Execute("flux",
             [
                 "bootstrap",
                 "github",
@@ -23,7 +26,16 @@ public class FluxClient : IFluxClient
                 "--repository=vdk-flux",
                 $"--branch={branch}",
                 $"--path={path}",
-                "--read-write-key=false"
+                "--read-write-key=false",
+                "--verbose"
             ]);
+            
+        } catch (Exception ex)
+        {
+            _console.WriteLine($"Error bootstrapping: {ex.Message}");
+        }
+        
+        _console.WriteLine("Flux bootstrap complete.");
+        
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Title
[Provide a succinct and descriptive title for the pull request, e.g., "Improve caching mechanism for API calls"]

## Type of Change
- [ ] New feature
- [X] Bug fix
- [X] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Add an env var option to override the 443 default reverse proxy.
Enforce vega namespace
Some exceptions catching for a better  understanding of errors
Handle host.docker.internal for linux systems.
Change the name of nginx and registry docker images because the names are pretty common and easily conflicting....

## Testing
Local testing

## Impact
We will have to discuss the flux bootstrap

## Additional Information
[Any additional information that reviewers should be aware of.]

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings 
