### PR TITLE
Update build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [x64, x86, arm, arm64]
+        rid: [linux-x64, linux-arm, linux-arm64, linux-musl-x64, linux-musl-arm64]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
 
       - name: Publish Linux Build
         run: |
-          RUNTIME_ID=linux-${{ matrix.arch }}
+          RUNTIME_ID=${{ matrix.rid }}
           OUTPUT_DIR=./packages/build/${RUNTIME_ID}
           ARTIFACT=vega-${RUNTIME_ID}.tar.gz
           dotnet publish ./cli/src/Vdk/Vdk.csproj -o $OUTPUT_DIR -r $RUNTIME_ID -c Release -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:IncludeNativeLibrariesForSelfExtract=true -p:IncludeAllContentForSelfExtract=true -p:selfcontained=true
@@ -58,8 +58,8 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.arch }}-tarball
-          path: ./artifacts/vega-linux-${{ matrix.arch }}.tar.gz
+          name: ${{ matrix.rid }}-tarball
+          path: ./artifacts/vega-${{ matrix.rid }}.tar.gz
 
   release:
     needs: build


### PR DESCRIPTION
This pull request updates the `.github/workflows/build.yaml` file to improve the build process by replacing the architecture-based matrix with a runtime identifier (RID)-based matrix. This change ensures better compatibility with different Linux environments and simplifies the naming conventions for artifacts.

### Workflow improvements:

* Updated the matrix strategy to use `rid` (runtime identifiers) instead of `arch` (architectures). The new RIDs include `linux-x64`, `linux-arm`, `linux-arm64`, `linux-musl-x64`, and `linux-musl-arm64`. (`[.github/workflows/build.yamlL16-R16](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L16-R16)`)
* Replaced the `RUNTIME_ID` assignment in the "Publish Linux Build" step to use `matrix.rid` instead of `matrix.arch`, aligning with the updated matrix strategy. (`[.github/workflows/build.yamlL48-R48](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L48-R48)`)
* Updated the artifact upload step to use `matrix.rid` for both the artifact name and path, ensuring consistency with the new RID-based naming convention. (`[.github/workflows/build.yamlL61-R62](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L61-R62)`)