### PR TITLE
Update build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rid: [linux-x64, linux-arm, linux-arm64, linux-musl-x64, linux-musl-arm64]
+        rid: [linux-x64, linux-arm, linux-arm64, linux-musl-x64, linux-musl-arm64, osx-x64, osx-arm64]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the build workflow configuration to expand platform support in the matrix of runtime identifiers (RIDs).

### Workflow configuration updates:
* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L16-R16): Added `osx-x64` and `osx-arm64` to the list of runtime identifiers (`rid`) in the build matrix, enabling support for macOS platforms.