### PR TITLE
Add new Workflow

### DIFF
--- a/.github/workflows/certificate-renewal.yaml
+++ b/.github/workflows/certificate-renewal.yaml
@@ -1,0 +1,40 @@
+name: Certbot Renewal
+
+on:
+  schedule:
+    - cron: 0 0 */60 * *
+
+jobs:
+  certbot-renewal:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Login to Cloudflare
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          curl -X POST \
+            https://api.cloudflare.com/client/v4/user/tokens/verify \
+            -H 'Content-Type: application/json' \
+            -d '{"token": "${CLOUDFLARE_API_TOKEN}"}'
+      - name: Create /tmp/certs directory
+        run: mkdir -p /tmp/certs
+      - name: Run Certbot
+        env:
+          CERTBOT_DOMAINS: dev-k8s.cloud
+          CERTBOT_EMAIL: ${{ secrets.CERTBOT_EMAIL}} 
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          RENEWAL_INTERVAL: 0
+          REPLACE_SYMLINKS: true
+        run: |
+          docker run -e CERTBOT_DOMAINS="dev-k8s.cloud" \
+            -e CERTBOT_EMAIL="${CERTBOT_EMAIL}" \
+            -e CLOUDFLARE_API_TOKEN="${CLOUDFLARE_API_TOKEN}" \
+            -e RENEWAL_INTERVAL=0 \
+            -e REPLACE_SYMLINKS=true \
+            -v /tmp/certs:/etc/letsencrypt serversideup/certbot-dns-cloudflare:latest
+      - name: Update Certs
+        run: |
+          cp /tmp/certs/live/dev-k8s.cloud/privkey.pem $(pwd)/certs/privkey.pem
+          cp /tmp/certs/live/dev-k8s.cloud/fullchain.pem $(pwd)/certs/fullchain.pem

--- a/.github/workflows/certificate-renewal.yaml
+++ b/.github/workflows/certificate-renewal.yaml
@@ -35,7 +35,7 @@ jobs:
             -e RENEWAL_INTERVAL=0 \
             -e REPLACE_SYMLINKS=true \
             -v /tmp/certs:/etc/letsencrypt serversideup/certbot-dns-cloudflare:latest
-      - name: Update Certs
+      - name: Copy renewed certificates to repository
         run: |
           cp /tmp/certs/live/dev-k8s.cloud/privkey.pem $(pwd)/certs/privkey.pem
           cp /tmp/certs/live/dev-k8s.cloud/fullchain.pem $(pwd)/certs/fullchain.pem

--- a/.github/workflows/certificate-renewal.yaml
+++ b/.github/workflows/certificate-renewal.yaml
@@ -1,15 +1,16 @@
 name: Certbot Renewal
 
 on:
+  workflow_dispatch:
   schedule:
-    - cron: 0 0 */60 * *
+    - cron: '0 0 1 * *'
 
 jobs:
   certbot-renewal:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Login to Cloudflare
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -42,10 +43,13 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-      - name: Commit and Push Changes
+      - name: Create Pull Request for Cert Updates
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          BRANCH=certbot-update-$(date +'%Y%m%d-%H%M%S')
+          git checkout -b $BRANCH
           git add certs/
           git commit -m "Update certificates [skip ci]" || echo "No changes to commit"
-          git push origin $(git rev-parse --abbrev-ref HEAD)
+          git push origin $BRANCH
+          gh pr create --title "Update certificates" --body "Automated certificate renewal PR." --head $BRANCH --base $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@') --fill

--- a/.github/workflows/certificate-renewal.yaml
+++ b/.github/workflows/certificate-renewal.yaml
@@ -38,3 +38,14 @@ jobs:
         run: |
           cp /tmp/certs/live/dev-k8s.cloud/privkey.pem $(pwd)/certs/privkey.pem
           cp /tmp/certs/live/dev-k8s.cloud/fullchain.pem $(pwd)/certs/fullchain.pem
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Commit and Push Changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git add certs/
+          git commit -m "Update certificates [skip ci]" || echo "No changes to commit"
+          git push origin $(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the renewal of SSL certificates using Certbot and Cloudflare. The workflow is scheduled to run every 60 days and includes steps for logging into Cloudflare, running Certbot in a Docker container, and updating the certificate files.

### New GitHub Actions Workflow for Certificate Renewal:

* `.github/workflows/certificate-renewal.yaml`: Added a new workflow named "Certbot Renewal" that runs every 60 days via a cron schedule. It includes steps to:
  - Check out the repository code.  
  - Authenticate with Cloudflare using an API token stored in GitHub Secrets.  
  - Create a temporary directory for storing certificates.  
  - Run Certbot in a Docker container to renew certificates for the domain `dev-k8s.cloud`.  
  - Copy the renewed certificates to the `certs` directory in the repository.