### PR TITLE
Bugfix/paths

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
+# Enforce LF line endings for all text files
+* text=auto eol=lf
+
 # Ensure all shell scripts use LF line endings
 *.sh text eol=lf

--- a/.github/workflows/certificate-renewal.yaml
+++ b/.github/workflows/certificate-renewal.yaml
@@ -36,7 +36,7 @@ jobs:
           RENEWAL_INTERVAL: 0
           REPLACE_SYMLINKS:  false
         run: |
-          docker run -e CERTBOT_DOMAINS="dev-k8s.cloud" \
+          docker run -e CERTBOT_DOMAINS="dev-k8s.cloud,*.dev-k8s.cloud" \
             -e CERTBOT_EMAIL="${CERTBOT_EMAIL}" \
             -e CLOUDFLARE_API_TOKEN="${CLOUDFLARE_API_TOKEN}" \
             -e RENEWAL_INTERVAL=0 \

--- a/cli/src/Vdk/Services/ReverseProxyClient.cs
+++ b/cli/src/Vdk/Services/ReverseProxyClient.cs
@@ -74,8 +74,8 @@ internal class ReverseProxyClient : IReverseProxyClient
             {
                 _console.WriteWarning($" - Reverse proxy configuration for {conf.FullName} exists, skipping creation of file. Ensure it has the right values.");
             }
-            var fullChain = new FileInfo("Certs/fullchain.pem");
-            var privKey = new FileInfo("Certs/privkey.pem");
+            var fullChain = new FileInfo(Path.Combine(".bin", "Certs", "fullchain.pem"));
+            var privKey = new FileInfo(Path.Combine(".bin", "Certs", "privkey.pem"));
             try
             {
                 _docker.Run(Containers.ProxyImage, Containers.ProxyName,


### PR DESCRIPTION
This pull request includes updates to enforce consistent line endings, improve certificate renewal configuration, and adjust file paths for reverse proxy certificate handling. Below is a summary of the most important changes:

### Line Ending Standardization:
* [`.gitattributes`](diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eR1-R3): Added a rule to enforce LF line endings for all text files, ensuring consistency across the repository.

### Certificate Renewal Configuration:
* [`.github/workflows/certificate-renewal.yaml`](diffhunk://#diff-bbf08b1417c27db3a52eb6d71c9240cde2b36c077174fb7e6b90acf75bee7fb8L39-R39): Updated the `CERTBOT_DOMAINS` environment variable to include wildcard domains (e.g., `*.dev-k8s.cloud`) for broader certificate coverage.

### Reverse Proxy Certificate Handling:
* [`cli/src/Vdk/Services/ReverseProxyClient.cs`](diffhunk://#diff-9d1551a1e1d10111597a0613aa1f7ec2f1344744ae1109d317638f89241412e0L77-R78): Updated file paths for `fullchain.pem` and `privkey.pem` to use `Path.Combine` with a `.bin` directory, improving cross-platform compatibility and organization.