### PR TITLE
Skip Docker tests when Docker isn't available

### DIFF
--- a/cli/tests/Vdk.Tests/Vdk.Tests.csproj
+++ b/cli/tests/Vdk.Tests/Vdk.Tests.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Make FallbackDockerEngine tests safe to run on machines without Docker by checking connectivity in the test constructor and skipping tests when Docker is unavailable. Replaced [Fact] with [SkippableFact], added Skip.IfNot(_dockerAvailable, ...) to each test, and only pull the test image when Docker can be reached. Added a using Xunit and added the Xunit.SkippableFact package to the test project so tests can be conditionally skipped.

